### PR TITLE
Fix errors from olive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.0   - 2024-05-03
+- Add conditional logic to re-attempt mavis with adjusted sample_bin_size if the config is not successfully generated
+
 ## 1.2.0   - 2024-04-09
 - Add GRIDSS as an allowable SV input
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,13 @@ Output | Type | Description
 
  ```
      
-     snakemake --jobs 100 --configfile=CONFIG_FILE -s Snakefile
+     snakemake --jobs 40 --configfile=CONFIG_FILE -s Snakefile &
+     wait
+
+     if [ ! -f CONFIG_FILE ]; then
+       sed -i 's/bin_size": 1000/bin_size": MAX_BINS/' CONFIG_FILE
+       snakemake --jobs 40 --configfile= CONFIG_FILE -s Snakefile
+     fi
  
  
      if [ -f OUTPUT_DIRECTORY/summary/MAVIS.COMPLETE ]; then

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Parameter|Value|Default|Description
 `generateConfig.filterTransHomopolymers`|Boolean?|False|When enabled, transcript sequences containing homopolymer regions are removed
 `generateConfig.jobMemory`|Int|6|Memory allocated for this job
 `generateConfig.timeout`|Int|6|Timeout in hours, needed to override imposed limits
-`runMavis.jobMemory`|Int|36|Memory allocated for this job
+`runMavis.jobMemory`|Int|120|Memory allocated for this job
 `runMavis.timeout`|Int|24|Timeout in hours, needed to override imposed limits
 
 

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -86,6 +86,7 @@
             "mavis3.runMavis.configFile": null,
             "mavis3.runMavis.outputFileNamePrefix": null,
             "mavis3.runMavis.modules": null,
+            "mavis3.runMavis.maxBins": null,
             "mavis3.runMavis.jobMemory": null,
             "mavis3.runMavis.timeout": null
         },


### PR DESCRIPTION
A few samples failed in the olive due to exceeding the memory limit for runMavis, so I've updated it here. Additionally, there was one sample failing with Zero Division and Index out of Range errors, which have also been seen in mavis2. I added a new conditional block to runMavis which checks if the config file has been generated for mavis3, and if it hasn't, it adjusts the sample_bin_size parameter and attempts to re-generate the config again. This solution is not 100% effective, but generally has been working. If the action still fails, the action can be attempted again, and will likely work the next time.